### PR TITLE
Note that packages should not distinguish runlevels 2-5

### DIFF
--- a/additions
+++ b/additions
@@ -1,11 +1,7 @@
-runlevels? "To the extent this says anything, it should be "Debian does
-not define different behavior for different numeric sysvinit runlevels
-2-5, though sysadmins may do so themselves.  Packages should always
-install init scripts into all numeric runlevels 2-5."  (Plus discussion
-about 0, 1, 6, etc.)"
-
 What should be included in maintainer scripts for systemd?
 
 rcS.d: ""don't".  These days, I wonder if Policy should hold new rcS
 scripts to the same standard as Pre-Depends: "ask if you think you need
 to add a new one"."
+
+Discuss runlevels 0, 1, 6, etc?

--- a/init-policy.sgml
+++ b/init-policy.sgml
@@ -227,6 +227,10 @@
       in different states, corresponding to a different combination
       of running services. In Debian, runlevels 2, 3, 4 and 5 are by
       default treated as equivalent, and the default runlevel is 2.
+      Administrators may use runlevels to configure sets of services or other
+      system behaviors, but packages should not make any assumptions about
+      different runlevels by default; packages should always install their init
+      scripts into all runlevels 2-5, not a subset of those runlevels.
       </p>
 
       <p>Scripts are associated with a runlevel by placing symlinks in


### PR DESCRIPTION
The administrator may make such distinctions, but packages should not.
